### PR TITLE
Fix bitwise operation in `readUnsignedVarInt`

### DIFF
--- a/Serializers.h
+++ b/Serializers.h
@@ -112,7 +112,7 @@ static inline bool readUnsignedVarInt(unsigned char* bytes, size_t used, size_t&
 		}
 
 		auto byte = bytes[offset++];
-		result |= (byte & VarIntConstants::VALUE_MASK) << shift;
+		result |= ((TValue)(byte & VarIntConstants::VALUE_MASK)) << shift;
 		if ((byte & VarIntConstants::MSB_MASK) == 0) {
 			return true;
 		}


### PR DESCRIPTION
# Problem

Method `VarInt::readUnsignedLong()` works incorrectly due to an bug in C function `readUnsignedVarInt`.

# Description

The method reads the first 4 bytes (while bitwise shift is less than 32), and ignores the rest.
This is happens because of the compiler makes implicit cast of `unsigned char` to `int` in bitwise shift operation. An integer value is shifted by`7 * 5 (35)` bits and more, so it becomes `0`.

# Reproducing

Code:
```php
<?php

use pocketmine\utils\Binary;

$buf_valid = chr(1 | 0x80) // 1
    . chr(1 | 0x80) // 2
    . chr(1 | 0x80) // 3
    . chr(1 | 0x80) // 4
    . chr(1) // 5
;

$buf_invalid = chr(1 | 0x80) // 1
    . chr(1 | 0x80) // 2
    . chr(1 | 0x80) // 3
    . chr(1 | 0x80) // 4
    . chr(1 | 0x80) // 5
    . chr(1 | 0x80) // 6
    . chr(1 | 0x80) // 7
    . chr(1 | 0x80) // 8
    . chr(1)        // 9
;

foreach ([$buf_valid, $buf_invalid] as $i => $input) {
    $offset_PHP = 0;
    $v_PHP = Binary::readUnsignedVarLong($input, $offset_PHP);

    $offset_C = 0;
    $v_C = CBinary::readUnsignedVarLong($input, $offset_C);

    if ($v_PHP === $v_C && $offset_PHP === $offset_C) {
        echo "Test $i passed\n";
        continue;
    }

    echo "Test $i failed\n";
    echo "PHP: offset=$offset_PHP\n";
    echo "C: offset=$offset_C\n";
    echo "PHP: value=$v_PHP\n";
    echo "C: value=$v_C\n";
    echo PHP_EOL;
}
```

Output:
```
Test 0 passed
Test 1 failed
PHP: offset=9
C: offset=9
PHP: value=72624976668147841
C: value=287458441
```

# Solution

Add explicit cast of `unsigned char` to type `TValue` in evaluations with `byte` variable in `readUnsignedVarInt`.
